### PR TITLE
guard user from access match detail if match already started

### DIFF
--- a/src/components/alertMessage.tsx
+++ b/src/components/alertMessage.tsx
@@ -5,7 +5,7 @@
  */
 interface Props {
     message: string;
-    type: "success" | "error" | "loading";
+    type: "success" | "error" | "loading" | "default";
 }
 
 /**
@@ -19,6 +19,7 @@ export default function AlertMessage(props: Props) {
         success: "bg-green-100 border-green-400 text-green-700",
         error: "bg-red-100 border-red-400 text-red-700",
         loading: "bg-blue-100 border-blue-400 text-blue-700",
+        default: "bg-black text-white bg-opacity-100",
     };
 
     return (

--- a/src/lib/resources/models/Match.ts
+++ b/src/lib/resources/models/Match.ts
@@ -123,6 +123,12 @@ const matchSchema = new Schema<Match>({
         default: null
     },
 
+    // This is the resume time
+    matchResume: {
+        type: Date,
+        default: null
+    },
+
     // This is the match details, also a place where you can input extra details eg. Discord link, Facebook messenger link etc.
     description: {
         type: String
@@ -146,7 +152,7 @@ const matchSchema = new Schema<Match>({
     // This is the status of the match
     status: {
         type: String,
-        enum: ["UPCOMING", "INPROGRESS", "FINISHED", "CANCELLED", "PAUSED"],
+        enum: ["UPCOMING", "INPROGRESS", "FINISHED", "CANCELLED", "PAUSED", "RESUMED"],
         required: true,
         default: "UPCOMING"
     },

--- a/src/lib/types/Match.ts
+++ b/src/lib/types/Match.ts
@@ -10,7 +10,7 @@ export namespace Matches {
 	export type TeamStatus = "WIN" | "LOSE" | "DRAW" | "UNSET";
 
 	// Matches status type
-	export type MatchStatus = "UPCOMING" | "INPROGRESS" | "FINISHED" | "CANCELLED" | "PAUSED";
+	export type MatchStatus = "UPCOMING" | "INPROGRESS" | "FINISHED" | "CANCELLED" | "PAUSED" | "RESUMED";
 }
 
 /**
@@ -77,5 +77,8 @@ export interface Match {
 
 	//This is the match pause time;
 	matchPause: Date | null;
+
+	//This is the match resume time;
+	matchResume: Date | null;
 }
 

--- a/src/pages/api/match/[id]/operation/[operation].tsx
+++ b/src/pages/api/match/[id]/operation/[operation].tsx
@@ -32,7 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         //all available operations
-        const operations = ["pause", "start", "queue", "cancel", "remove", "finish"];
+        const operations = ["pause", "start", "queue", "cancel", "remove", "finish", "resume"];
 
         //destructure request params to get id and operation name
         const { id, operation } = req.query;
@@ -144,10 +144,40 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             });
         }
 
+        if (operation === "resume") {
+            const { resumeTime } = req.body;
+
+            //validate resumeTime
+            if (isNaN(Date.parse(resumeTime))) {
+                throw {
+                    code: 400,
+                    message: "bad request"
+                };
+            }
+
+            //update matchResume
+            await updateMatchFields(id, {
+                matchResume: resumeTime,
+                status: "RESUMED",
+            });
+        }
+
         //operation happens when the host cancel the match
         if (operation === "cancel") {
+            const { cancelTime } = req.body;
+
+            //validate cancelTime
+            if (isNaN(Date.parse(cancelTime))) {
+                throw {
+                    code: 400,
+                    message: "bad request"
+                };
+            }
+
+            //cancel match
             await updateMatchFields(id, {
                 status: "CANCELLED",
+                matchEnd: cancelTime,
             });
         }
 

--- a/src/pages/api/match/create.ts
+++ b/src/pages/api/match/create.ts
@@ -26,7 +26,6 @@ export default async function handler(
                 matchType,
                 location,
                 matchStart,
-                matchEnd,
                 description,
                 teams,
                 status,
@@ -104,7 +103,8 @@ export default async function handler(
                 teams,
                 status,
                 matchQueueStart: null,
-                matchPause: null
+                matchPause: null,
+                matchResume: null,
             };
 
             // Call upon the createMatch action to use the values above and create a match model

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -93,10 +93,10 @@ export default function Login() {
                     <div className={styles.about}>
                         <h2>Are YOU the MVP?</h2>
                         <p>
-              Create your matches <br />
-              Schedule your face-off
+                            Create your matches <br />
+                            Schedule your face-off
                             <br />
-              Put your skills to the test.
+                            Put your skills to the test.
                         </p>
                         <h2>Can you be #1?</h2>
                     </div>
@@ -124,7 +124,7 @@ export default function Login() {
                                     <EmailIcon />
                                 </Input>
                                 <Button type="submit" className={styles.login}>
-                  Log in
+                                    Log in
                                 </Button>
                             </form>
                             <div className="flex w-full items-center gap-2 my-5">

--- a/src/pages/match/[id]/index.tsx
+++ b/src/pages/match/[id]/index.tsx
@@ -335,13 +335,13 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
             };
         }
 
+        //guard against regular match already start,
         //update match status and redirect to scoreboard if start time is passed
         if (
             match.matchType === "REGULAR" &&
             new Date(match.matchStart!.toLocaleString()).getTime() <= new Date(new Date(Date.now()).toLocaleString()).getTime()
         ) {
-            const alreadyStartedMatchStatus = ["INPROGRESS", "PAUSED", "RESUMED", "FINISHED", "CANCELLED"];
-            if (!alreadyStartedMatchStatus.includes(match.status)) {
+            if (match.status === "UPCOMING") {
                 await updateMatchStatus(id as string, "INPROGRESS");
             }
 

--- a/src/pages/match/[id]/scoreboard.tsx
+++ b/src/pages/match/[id]/scoreboard.tsx
@@ -7,6 +7,7 @@ import axios from "axios";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import debounce from "lodash.debounce";
+import Snackbar from "@mui/material/Snackbar";
 
 //local import
 import { getMatchById } from "@/lib/actions/match";
@@ -18,6 +19,7 @@ import styles from "@/styles/Scoreboard.module.sass";
 import fetcher from "@/lib/helpers/fetcher";
 import { UserProfile } from "@/lib/types/User";
 import { mapPlayerToTeam } from "@/lib/helpers/scoreboard";
+import AlertMessage from "@/components/alertMessage";
 
 /**
  * scoreboard props type
@@ -54,6 +56,9 @@ export default function Scoreboard({ match, players }: Props) {
             }
         }
     }, [session, status, router, match]);
+
+    //snackbar state
+    const [snackbar, setSnackbar] = useState(false);
 
     //match state
     const [currMatch, setMatch] = useState<Match>(match);
@@ -181,42 +186,25 @@ export default function Scoreboard({ match, players }: Props) {
                 clearInterval(queuingTimer as NodeJS.Timeout);
                 setQueueTimer(null);
 
-                //set match timer to null, if match does not have enough members
-                if (!isMemberFull) {
-                    await axios.put(`/api/match/${currMatch._id?.toString()}/time/start`, {
-                        startTime: null
-                    });
-                    await axios.put(`/api/match/${currMatch._id?.toString()}/status`, {
-                        status: "UPCOMING"
-                    });
-                    setMatchTimer(null);
-                    clearInterval(gameTimer as NodeJS.Timeout);
-                }
+                //timer start from start time
+                gameTimer = setInterval(async()=> {
 
-                //checks if the match is paused
-                if(currMatch.matchPause){
-
-                    //get pause time
-                    const pauseTimer = new Date(new Date(currMatch.matchPause).toUTCString()).getTime();
-
-                    //get time difference start and pause time
-                    const timePassed = Math.floor((pauseTimer - startTimer) / 1000);
-
-                    //if match is in progress, start the timer from the time difference else stop timer, clear the interval
-                    gameTimer = setInterval(async()=> {
-                        const now = new Date(new Date().toUTCString()).getTime();
-                        const timeDiff = Math.floor((now - pauseTimer)/1000) + timePassed;
-                        setMatchTimer(timeDiff);
-                    }, 1000);
-                } else {
-
-                    //timer start from start time
-                    gameTimer = setInterval(async()=> {
+                    //set match timer to null, if match does not have enough members
+                    if (!isMemberFull) {
+                        await axios.put(`/api/match/${currMatch._id?.toString()}/time/start`, {
+                            startTime: null
+                        });
+                        await axios.put(`/api/match/${currMatch._id?.toString()}/status`, {
+                            status: "UPCOMING"
+                        });
+                        setMatchTimer(null);
+                        clearInterval(gameTimer as NodeJS.Timeout);
+                    } else {
                         const now = new Date(new Date().toUTCString()).getTime();
                         const timeDiff = Math.floor((now - startTimer) / 1000);
                         setMatchTimer(timeDiff);
-                    }, 1000);
-                }
+                    }
+                }, 1000);
             } else if (currMatch.status === "PAUSED" && currMatch.matchPause) {
 
                 //match start time
@@ -226,11 +214,36 @@ export default function Scoreboard({ match, players }: Props) {
                 const pauseTimer = new Date(new Date(currMatch.matchPause).toUTCString()).getTime();
 
                 //get time difference start and pause time in seconds
-                const timePassed = Math.floor((pauseTimer - startTimer) / 1000);
+                const startToPause = Math.floor((pauseTimer - startTimer) / 1000);
 
                 //set timer to the point user hit click pause
-                setMatchTimer(timePassed);
+                setMatchTimer(startToPause);
                 clearInterval(gameTimer as NodeJS.Timeout);
+            } else if (currMatch.status === "RESUMED" && currMatch.matchResume) {
+
+                //match start time
+                const startTimer = new Date(new Date(currMatch.matchStart!).toUTCString()).getTime();
+
+                //match pause time
+                const pauseTimer = new Date(new Date(currMatch.matchPause!).toUTCString()).getTime();
+
+                //match resume time
+                const resumeTimer = new Date(new Date(currMatch.matchResume).toUTCString()).getTime();
+
+                //const time difference between pause and resume time in seconds
+                const pauseToResume = Math.floor((resumeTimer - pauseTimer) / 1000);
+
+                //const time difference between start and resume time in seconds
+                const startToPause = Math.floor((pauseTimer - startTimer) / 1000);
+
+                //const resume to now
+                const resumeToNow = Math.floor((new Date().getTime() - resumeTimer) / 1000);
+
+                gameTimer = setInterval(async()=> {
+                    const now = new Date(new Date().toUTCString()).getTime();
+                    const timeDiff = Math.floor((now - pauseTimer) / 1000) + resumeToNow - pauseToResume + startToPause;
+                    setMatchTimer(timeDiff);
+                }, 1000);
             }
         }
         updateTimer();
@@ -244,26 +257,16 @@ export default function Scoreboard({ match, players }: Props) {
 
     //function for the host to pause the match
     const pauseMatch = debounce(async()=> {
-        try{
-            if(currMatch.status === "PAUSED") return;
-            await axios.put(`/api/match/${currMatch._id?.toString()}/operation/pause`, {
-                pauseTime: new Date().toString()
-            });
-        } catch(err: any){
-            alert(err.response.data.message);
-        }
-    }, 500);
 
-    //function for the host to resume the match after pausing
-    const resumeMatch = debounce(async()=> {
-        try{
-            if(currMatch.status === "INPROGRESS") return;
-            await axios.put(`/api/match/${currMatch._id?.toString()}/status`, {
-                status: "INPROGRESS"
-            });
-        } catch(err: any){
-            alert(err.response.data.message);
-        }
+        // try {
+        //     if(currMatch.status === "PAUSED") return;
+        //     await axios.put(`/api/match/${currMatch._id?.toString()}/operation/pause`, {
+        //         pauseTime: new Date().toString()
+        //     });
+        // } catch(err: any){
+        //     alert(err.response.data.message);
+        // }
+        setSnackbar(true);
     }, 500);
 
     //function for host to end the match
@@ -278,8 +281,22 @@ export default function Scoreboard({ match, players }: Props) {
     //function for host to cancel the match
     const cancelMatch = debounce(async()=> {
         try{
-            await axios.put(`/api/match/${currMatch._id?.toString()}/operation/cancel`);
+            await axios.put(`/api/match/${currMatch._id?.toString()}/operation/cancel`, {
+                cancelTime: new Date().toString()
+            });
         } catch(err: any) {
+            alert(err.response.data.message);
+        }
+    }, 500);
+
+    //function for host to resume the match after pausing
+    const resumeMatch = debounce(async()=> {
+        try{
+            if(currMatch.status === "INPROGRESS") return;
+            await axios.put(`/api/match/${currMatch._id?.toString()}/operation/resume`, {
+                resumeTime: new Date().toString()
+            });
+        } catch(err: any){
             alert(err.response.data.message);
         }
     }, 500);
@@ -310,6 +327,20 @@ export default function Scoreboard({ match, players }: Props) {
 
     return(
         <div className={styles.page}>
+            <Snackbar
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+                open={snackbar}
+                autoHideDuration={10000}
+                onClose={()=> setSnackbar(false)}
+            >
+                <p className="w-full bg-black p-5 drop-shadow-lg z-50">
+                    <span className="text-yellow-500">⚠️ </span>
+                    <span className="text-white">
+                        This feature is currently in development and will be available in the future.
+                        We&apos;re sorry for any inconvenience 🙇
+                    </span>
+                </p>
+            </Snackbar>
             <div className="relative h-7 w-full">
                 <Image
                     src="/crown.svg"
@@ -423,7 +454,7 @@ export default function Scoreboard({ match, players }: Props) {
                 </div>
                 { isMatchHost &&
                     <>
-                        { currMatch.status === "INPROGRESS" &&
+                        { (currMatch.status === "INPROGRESS" || currMatch.status === "RESUMED") &&
                             <button onClick={pauseMatch} className={`${styles.pause} text-base p-5`}>
                                 Pause
                             </button>
@@ -433,7 +464,7 @@ export default function Scoreboard({ match, players }: Props) {
                                 Resume
                             </button>
                         }
-                        { (currMatch.status === "INPROGRESS" || currMatch.status === "PAUSED") &&
+                        { (currMatch.status === "INPROGRESS" || currMatch.status === "PAUSED" || currMatch.status === "RESUMED") &&
                             <button
                                 className={`${styles.finish} text-base p-5`}
                                 onClick={endMatch}


### PR DESCRIPTION
- Using snackbar to display error in create match and scoreboard
- guard user from accessing match detail page for already started match (regular match)
- format start time display on detail page
- disabled paused features of scoreboard